### PR TITLE
added check and testing of check for mising h5m file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 *.gz
 tests/fusion_example_for_openmc_using_paramak-0.0.1/
+*.h5m

--- a/dagmc_h5m_file_inspector/core.py
+++ b/dagmc_h5m_file_inspector/core.py
@@ -1,4 +1,5 @@
 
+from pathlib import Path
 from typing import List, Optional
 
 import pymoab as mb
@@ -14,6 +15,10 @@ def load_moab_file(filename: str):
     Returns:
         A pymoab.core.Core()
     """
+
+    if not Path(filename).is_file():
+        msg = f"filename provided ({filename}) does not exist"
+        raise FileNotFoundError(msg)
 
     moab_core = core.Core()
     moab_core.load_file(filename)

--- a/tests/test_python_api_usage.py
+++ b/tests/test_python_api_usage.py
@@ -149,7 +149,6 @@ class TestApiUsage(unittest.TestCase):
             "tungsten",
         ]
 
-
     def test_fail_with_missing_input_files(self):
         """Calls functions without necessary input files to check if error
         handeling is working"""

--- a/tests/test_python_api_usage.py
+++ b/tests/test_python_api_usage.py
@@ -148,3 +148,20 @@ class TestApiUsage(unittest.TestCase):
             "steel",
             "tungsten",
         ]
+
+
+    def test_fail_with_missing_input_files(self):
+        """Calls functions without necessary input files to check if error
+        handeling is working"""
+
+        def test_missing_file_error_handling():
+            """Attempts to get info when the h5m file does not exist which
+            should fail with a FileNotFoundError"""
+
+            di.get_volumes_and_materials_from_h5m(
+                filename="non_existant.h5m",
+            )
+
+        self.assertRaises(
+            FileNotFoundError,
+            test_missing_file_error_handling)


### PR DESCRIPTION
raises a file not found error if a a user tries to load a non existent h5m file 