### PR TITLE
Write material_names as ASCII so VTK's VTKHDF reader can open the file

### DIFF
--- a/src/dagmc_h5m_file_inspector/core.py
+++ b/src/dagmc_h5m_file_inspector/core.py
@@ -2576,7 +2576,11 @@ def _write_vtkhdf(
         cell_data.create_dataset("material_id", data=material_ids.astype(np.int32))
 
         field_data = root.create_group("FieldData")
-        dt = h5py.string_dtype()
+        # Use ASCII (not the default UTF-8) variable-length strings. VTK's VTKHDF
+        # reader (e.g. VTK 9.6) cannot convert UTF-8 string datasets and raises
+        # "no appropriate function for conversion path" / H5Dread errors when the
+        # file is opened, whereas ASCII variable-length strings read correctly.
+        dt = h5py.string_dtype("ascii")
         field_data.create_dataset("material_names", data=material_names, dtype=dt)
 
 

--- a/tests/test_python_api_usage.py
+++ b/tests/test_python_api_usage.py
@@ -1285,6 +1285,28 @@ def test_convert_h5m_to_vtkhdf_cell_data(touching_boxes, tmp_path):
                 assert np.all(material_ids[mask] == expected_mat_id)
 
 
+def test_convert_h5m_to_vtkhdf_material_names_ascii(touching_boxes, tmp_path):
+    """material_names must be stored as ASCII strings.
+
+    VTK's VTKHDF reader (e.g. VTK 9.6) cannot convert UTF-8 string datasets and
+    fails to open the file with an H5Dread "no appropriate function for
+    conversion path" error. ASCII variable-length strings read correctly, so we
+    pin the charset to guard against a regression to the default UTF-8 encoding.
+    """
+
+    output_file = str(tmp_path / "output.vtkhdf")
+    di.convert_h5m_to_vtkhdf(
+        h5m_filename=touching_boxes["filename"],
+        vtkhdf_filename=output_file,
+    )
+
+    with h5py.File(output_file, "r") as f:
+        dt = f["VTKHDF/FieldData/material_names"].dtype
+        string_info = h5py.check_string_dtype(dt)
+        assert string_info is not None, "material_names is not a string dataset"
+        assert string_info.encoding == "ascii"
+
+
 def test_convert_h5m_to_vtkhdf_default_filename(touching_boxes, tmp_path):
     """Test that omitting vtkhdf_filename produces correct default"""
 


### PR DESCRIPTION
## Problem

`convert_h5m_to_vtkhdf` wrote the `material_names` FieldData with `h5py.string_dtype()`, which defaults to **UTF-8**. VTK's VTKHDF reader (e.g. VTK 9.6, as bundled with recent pyvista) cannot convert UTF-8 string datasets and fails to open the file the moment it is read:

```
H5Dread(): can't synchronously read data
H5T_path_find_real(): no appropriate function for conversion path
vtkHDFUtilities.cxx:633 ERR| (nullptr): Error H5Dread
```

This breaks `pyvista.read('dagmc.vtkhdf')` even though the geometry and `material_id`/`cell_id` cell arrays are perfectly valid.

## Fix

Write `material_names` using a variable-length **ASCII** string dtype (`h5py.string_dtype("ascii")`). VTK reads ASCII string datasets correctly, the names round-trip, and the rest of the file is unchanged. Material tag names are ASCII in practice, so no information is lost.

## Test

Added `test_convert_h5m_to_vtkhdf_material_names_ascii` which asserts the dataset's charset is ASCII (via `h5py.check_string_dtype`), guarding against a regression to the default UTF-8 encoding. All existing vtkhdf tests still pass.